### PR TITLE
Contract/ERC20-create-initial-contract

### DIFF
--- a/blockchain/contracts/ChangeCoin.sol
+++ b/blockchain/contracts/ChangeCoin.sol
@@ -10,14 +10,31 @@ pragma solidity ^0.8.20;
 // libary imports
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 
 
-contract ChangeCoin is Initializable, ERC20Upgradeable {
+contract ChangeCoin is Initializable, ERC20Upgradeable, UUPSUpgradeable, OwnableUpgradeable {
     /**
-     * @notice initialize name of coin and coin symbol
-     * @dev initialize function replaces the solidity constructor in OpenZeppelin upgradeable proxy pattern contracts 
+     * @notice Initializes the contract with token details and sets up upgradeability
+     * @dev This function replaces the constructor in upgradeable contracts
+     * @dev __ERC20_init: Initializes the ERC20 token with name and symbol
+     * @dev __UUPSUpgradeable_init: Initializes the UUPS upgradeability pattern
+     * @dev __Ownable_init: Initializes ownership with the deployer as the owner
+     * @dev Mints initial supply to the deployer
      */
     function initialize() public initializer {
         __ERC20_init("ChangeCoin", "CNGX");
+        __UUPSUpgradeable_init();
+        __Ownable_init(msg.sender);
+        _mint(msg.sender, 1000000 * 10**decimals());
     }
+
+    /**
+     * @notice Authorizes an upgrade to a new implementation
+     * @dev This function is called by the UUPS proxy when an upgrade is attempted
+     * @dev The onlyOwner modifier ensures only the contract owner can authorize upgrades
+     * @param newImplementation The address of the new implementation contract
+     */
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner{}
 }

--- a/blockchain/contracts/ChangeCoin.sol
+++ b/blockchain/contracts/ChangeCoin.sol
@@ -37,4 +37,23 @@ contract ChangeCoin is Initializable, ERC20Upgradeable, UUPSUpgradeable, Ownable
      * @param newImplementation The address of the new implementation contract
      */
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner{}
+
+    /**
+     * @notice Mints new tokens to a specified address
+     * @dev Only the owner can mint new tokens
+     * @param to The address that will receive the minted tokens
+     * @param amount The amount of tokens to mint
+     */
+    function mint(address to, uint256 amount) public onlyOwner {
+        _mint(to, amount);
+    }
+
+    /**
+     * @notice Burns tokens from the caller's balance
+     * @dev Any token holder can burn their own tokens
+     * @param amount The amount of tokens to burn
+     */
+    function burn(uint256 amount) public {
+        _burn(msg.sender, amount);
+    }
 }

--- a/blockchain/contracts/ChangeCoin.sol
+++ b/blockchain/contracts/ChangeCoin.sol
@@ -1,0 +1,23 @@
+/**
+ * @title Change Coin Contract
+ * @author Anthony Spedaliere
+ * @notice This contract implements a basic upgradeable ERC20 token using open zeppelin library.
+ */
+
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// libary imports
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+
+
+contract ChangeCoin is Initializable, ERC20Upgradeable {
+    /**
+     * @notice initialize name of coin and coin symbol
+     * @dev initialize function replaces the solidity constructor in OpenZeppelin upgradeable proxy pattern contracts 
+     */
+    function initialize() public initializer {
+        __ERC20_init("ChangeCoin", "CNGX");
+    }
+}

--- a/blockchain/contracts/ChangeCoinProxy.sol
+++ b/blockchain/contracts/ChangeCoinProxy.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * @title ChangeCoinProxy
+ * @author Anthony Spedaliere
+ * @notice This contract is the UUPS proxy for the ChangeCoin implementation
+ * @dev This proxy contract delegates all calls to the ChangeCoin implementation
+ */
+contract ChangeCoinProxy is ERC1967Proxy {
+    /**
+     * @notice Constructor for the proxy contract
+     * @param implementation The address of the ChangeCoin implementation contract
+     * @param data The initialization data for the ChangeCoin contract
+     */
+    constructor(address implementation, bytes memory data) ERC1967Proxy(implementation, data) {}
+} 

--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "hardhat-project",
       "dependencies": {
+        "@openzeppelin/contracts": "^5.3.0",
         "@openzeppelin/contracts-upgradeable": "^5.3.0"
       },
       "devDependencies": {
@@ -958,8 +959,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.3.0.tgz",
       "integrity": "sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "5.3.0",

--- a/blockchain/package-lock.json
+++ b/blockchain/package-lock.json
@@ -5,6 +5,9 @@
   "packages": {
     "": {
       "name": "hardhat-project",
+      "dependencies": {
+        "@openzeppelin/contracts-upgradeable": "^5.3.0"
+      },
       "devDependencies": {
         "@nomicfoundation/hardhat-ignition": "^0.15.11",
         "hardhat": "^2.23.0"
@@ -949,6 +952,22 @@
       "optional": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-5.3.0.tgz",
+      "integrity": "sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@openzeppelin/contracts-upgradeable": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.3.0.tgz",
+      "integrity": "sha512-yVzSSyTMWO6rapGI5tuqkcLpcGGXA0UA1vScyV5EhE5yw8By3Ewex9rDUw8lfVw0iTkvR/egjfcW5vpk03lqZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@openzeppelin/contracts": "5.3.0"
       }
     },
     "node_modules/@scure/base": {

--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -5,6 +5,7 @@
     "hardhat": "^2.23.0"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^5.3.0",
     "@openzeppelin/contracts-upgradeable": "^5.3.0"
   }
 }

--- a/blockchain/package.json
+++ b/blockchain/package.json
@@ -3,5 +3,8 @@
   "devDependencies": {
     "@nomicfoundation/hardhat-ignition": "^0.15.11",
     "hardhat": "^2.23.0"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts-upgradeable": "^5.3.0"
   }
 }


### PR DESCRIPTION
# ERC20 Token Implementation with UUPS Upgradeability

## Changes
- Implemented ChangeCoin as an upgradeable ERC20 token
- Added UUPS proxy pattern for contract upgradeability
- Created ChangeCoinProxy for deployment

### ChangeCoin Contract Features
- ERC20 standard implementation with name "ChangeCoin" and symbol "CNGX"
- Initial supply of 1,000,000 tokens minted to deployer
- Owner-only minting capability
- Public burn function for token holders
- UUPS upgradeability with owner-only authorization
- Comprehensive NatSpec documentation

### ChangeCoinProxy Contract
- UUPS proxy implementation using OpenZeppelin's ERC1967Proxy
- Delegates all calls to ChangeCoin implementation
- Supports contract upgrades through UUPS pattern

## Security Considerations
- Owner-only access for minting and upgrades
- UUPS pattern for secure contract upgrades
- OpenZeppelin's battle-tested contracts used for core functionality